### PR TITLE
auto toggle touch controls

### DIFF
--- a/src/pc/controller/controller_api.c
+++ b/src/pc/controller/controller_api.c
@@ -1,0 +1,15 @@
+#include "controller_api.h"
+#if defined(__ANDROID__)
+    int curInputSource=touchScreen;
+#else
+    int curInputSource=keyboard;
+#endif
+
+
+void set_current_input(int in){
+    curInputSource=in;
+}
+
+int get_current_input(){
+    return curInputSource;
+}

--- a/src/pc/controller/controller_api.h
+++ b/src/pc/controller/controller_api.h
@@ -41,4 +41,16 @@ void controller_rumble_stop(void);
 // calls the shutdown() function of all controller subsystems
 void controller_shutdown(void);
 
+enum Input{
+    keyboard,
+    emscriptenKeyboard,
+    sdlGameController,
+    touchScreen,
+    wup,
+    xinput
+};
+
+extern void set_current_input(int in);
+extern int get_current_input();
+
 #endif

--- a/src/pc/controller/controller_sdl2.c
+++ b/src/pc/controller/controller_sdl2.c
@@ -31,6 +31,14 @@
 int mouse_x;
 int mouse_y;
 
+static int16_t rightx;
+static int16_t righty;
+
+static int16_t leftx;
+static int16_t lefty;
+static int16_t ltrig;
+static int16_t rtrig;
+
 #ifdef BETTERCAMERA
 extern u8 newcam_mouse;
 #endif
@@ -192,13 +200,25 @@ static void controller_sdl_read(OSContPad *pad) {
         }
     }
 
-    int16_t leftx = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_LEFTX);
-    int16_t lefty = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_LEFTY);
-    int16_t rightx = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_RIGHTX);
-    int16_t righty = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_RIGHTY);
+    int16_t previousLeftX = leftx;
+    int16_t previousLeftY = lefty;
+    int16_t previousRightX = rightx;
+    int16_t previousRightY = righty;
+    int16_t previousLTrig = ltrig;
+    int16_t previousRTrig = rtrig;
 
-    int16_t ltrig = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_TRIGGERLEFT);
-    int16_t rtrig = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_TRIGGERRIGHT);
+    leftx = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_LEFTX);
+    lefty = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_LEFTY);
+    rightx = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_RIGHTX);
+    righty = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_RIGHTY);
+
+    ltrig = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_TRIGGERLEFT);
+    rtrig = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_TRIGGERRIGHT);
+
+	bool inputChanged =false;
+
+    if(leftx!=previousLeftX||lefty!=previousLeftY||rightx!=previousRightX||righty!=previousRightY||ltrig!=previousLTrig||rtrig!=previousRTrig)
+        inputChanged = true;
 
 #ifdef TARGET_WEB
     // Firefox has a bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1606562
@@ -217,7 +237,12 @@ static void controller_sdl_read(OSContPad *pad) {
     for (u32 i = 0; i < SDL_CONTROLLER_BUTTON_MAX; ++i) {
         const bool new = SDL_GameControllerGetButton(sdl_cntrl, i);
         update_button(i, new);
+	if(new)
+	    inputChanged = true;
     }
+
+    if(inputChanged)
+        set_current_input(sdlGameController);
 
     update_button(VK_LTRIGGER - VK_BASE_SDL_GAMEPAD, ltrig > AXIS_THRESHOLD);
     update_button(VK_RTRIGGER - VK_BASE_SDL_GAMEPAD, rtrig > AXIS_THRESHOLD);

--- a/src/pc/controller/controller_touchscreen.c
+++ b/src/pc/controller/controller_touchscreen.c
@@ -57,6 +57,7 @@ static int ControlElementsLength = sizeof(ControlElementsDefault)/sizeof(struct 
                               ((pos.y + size / 2 > CORRECT_TOUCH_Y(event->y)) && (pos.y - size / 2 < CORRECT_TOUCH_Y(event->y))))
 
 void touch_down(struct TouchEvent* event) {
+    set_current_input(touchScreen);
     struct Position pos;
     for(int i = 0; i < ControlElementsLength; i++) {
         if (ControlElements[i].touchID == 0) {
@@ -184,6 +185,9 @@ static void DrawSprite(s32 x, s32 y, int scaling) {
 }
 
 void render_touch_controls(void) {
+    if(get_current_input()!=touchScreen)
+        return;
+
     Mtx *mtx;
 
     mtx = alloc_display_list(sizeof(*mtx));


### PR DESCRIPTION
Hides touch screen controls when controller input detected, displays them when touch input detected.
Courtesy of [JustMeDaFaq](https://github.com/VDavid003/sm64-port-android/compare/ex/nightly...JustMeDaFaq:sm64-port-android:ex/nightly)